### PR TITLE
Fix for erroneous time value handling on linux

### DIFF
--- a/src/include/private/clock.h
+++ b/src/include/private/clock.h
@@ -45,7 +45,7 @@ class UtcClock : public IClock {
       #else
       gmtime_r(&rawtime, &ptm);
       #endif
-      return mktime(&ptm);
+      return timegm(&ptm);
     }
 };
 #endif  // SRC_INCLUDE_PRIVATE_CLOCK_H_

--- a/src/include/private/clock.h
+++ b/src/include/private/clock.h
@@ -42,10 +42,11 @@ class UtcClock : public IClock {
       time(&rawtime);
       #ifdef _WIN32
       gmtime_s(&ptm, &rawtime);
+      return _mkgmtime(&ptm);
       #else
       gmtime_r(&rawtime, &ptm);
-      #endif
       return timegm(&ptm);
+      #endif
     }
 };
 #endif  // SRC_INCLUDE_PRIVATE_CLOCK_H_


### PR DESCRIPTION
I don't have windows at hand. I just looked up the equivalent function to "timegm" on MSDN. Therefore i was not able to test if this actually works on windows. 