### PR TITLE
Fix RSA validator empty RSA key loading check

### DIFF
--- a/src/validators/rsavalidator.cpp
+++ b/src/validators/rsavalidator.cpp
@@ -89,7 +89,7 @@ Error:
 
 EVP_PKEY *RSAValidator::LoadKey(const char *key, bool public_key) {
     EVP_PKEY *evp_pkey = NULL;
-    BIO *keybio = BIO_new_mem_buf(
+    BIO *keybio = !key || !*key ? NULL : BIO_new_mem_buf(
         const_cast<void *>(reinterpret_cast<const void *>(key)), -1);
     if (keybio == NULL) {
         return NULL;


### PR DESCRIPTION
The change allows signing RS* with just the private key (e.g. RS256Validator("", private_key)), and doing RS* validation with just the public key (in the case of using JWT::Decode(token, validator, claims) with JSON inputs).