### PR TITLE
Properly escape preprocessor maco expansions.

### DIFF
--- a/src/include/jwt/json.hpp
+++ b/src/include/jwt/json.hpp
@@ -6302,22 +6302,22 @@ private:
           // positive fixnum
           add_to_vector(v, 1, j.m_value.number_unsigned);
         } else if (j.m_value.number_unsigned <=
-                   std::numeric_limits<uint8_t>::(max)()) {
+                   (std::numeric_limits<uint8_t>::max)()) {
           // uint 8
           v.push_back(0xcc);
           add_to_vector(v, 1, j.m_value.number_unsigned);
         } else if (j.m_value.number_unsigned <=
-                   std::numeric_limits<uint16_t>::(max)()) {
+                   (std::numeric_limits<uint16_t>::max)()) {
           // uint 16
           v.push_back(0xcd);
           add_to_vector(v, 2, j.m_value.number_unsigned);
         } else if (j.m_value.number_unsigned <=
-                   std::numeric_limits<uint32_t>::(max)()) {
+                   (std::numeric_limits<uint32_t>::max)()) {
           // uint 32
           v.push_back(0xce);
           add_to_vector(v, 4, j.m_value.number_unsigned);
         } else if (j.m_value.number_unsigned <=
-                   std::numeric_limits<uint64_t>::(max)()) {
+                   (std::numeric_limits<uint64_t>::max)()) {
           // uint 64
           v.push_back(0xcf);
           add_to_vector(v, 8, j.m_value.number_unsigned);
@@ -6327,30 +6327,30 @@ private:
           // negative fixnum
           add_to_vector(v, 1, j.m_value.number_integer);
         } else if (j.m_value.number_integer >=
-                       std::numeric_limits<int8_t>::(min)() and
+                       (std::numeric_limits<int8_t>::min)() and
                    j.m_value.number_integer <=
-                       std::numeric_limits<int8_t>::(max)()) {
+                       (std::numeric_limits<int8_t>::max)()) {
           // int 8
           v.push_back(0xd0);
           add_to_vector(v, 1, j.m_value.number_integer);
         } else if (j.m_value.number_integer >=
-                       std::numeric_limits<int16_t>::(min)() and
+                       (std::numeric_limits<int16_t>::min)() and
                    j.m_value.number_integer <=
-                       std::numeric_limits<int16_t>::(max)()) {
+                       (std::numeric_limits<int16_t>::max)()) {
           // int 16
           v.push_back(0xd1);
           add_to_vector(v, 2, j.m_value.number_integer);
         } else if (j.m_value.number_integer >=
-                       std::numeric_limits<int32_t>::(min)() and
+                       (std::numeric_limits<int32_t>::min)() and
                    j.m_value.number_integer <=
-                       std::numeric_limits<int32_t>::(max)()) {
+                       (std::numeric_limits<int32_t>::max)()) {
           // int 32
           v.push_back(0xd2);
           add_to_vector(v, 4, j.m_value.number_integer);
         } else if (j.m_value.number_integer >=
-                       std::numeric_limits<int64_t>::(min)() and
+                       (std::numeric_limits<int64_t>::min)() and
                    j.m_value.number_integer <=
-                       std::numeric_limits<int64_t>::(max)()) {
+                       (std::numeric_limits<int64_t>::max)()) {
           // int 64
           v.push_back(0xd3);
           add_to_vector(v, 8, j.m_value.number_integer);
@@ -6364,22 +6364,22 @@ private:
         // positive fixnum
         add_to_vector(v, 1, j.m_value.number_unsigned);
       } else if (j.m_value.number_unsigned <=
-                 std::numeric_limits<uint8_t>::(max)()) {
+                 (std::numeric_limits<uint8_t>::max)()) {
         // uint 8
         v.push_back(0xcc);
         add_to_vector(v, 1, j.m_value.number_unsigned);
       } else if (j.m_value.number_unsigned <=
-                 std::numeric_limits<uint16_t>::(max)()) {
+                 (std::numeric_limits<uint16_t>::max)()) {
         // uint 16
         v.push_back(0xcd);
         add_to_vector(v, 2, j.m_value.number_unsigned);
       } else if (j.m_value.number_unsigned <=
-                 std::numeric_limits<uint32_t>::(max)()) {
+                 (std::numeric_limits<uint32_t>::max)()) {
         // uint 32
         v.push_back(0xce);
         add_to_vector(v, 4, j.m_value.number_unsigned);
       } else if (j.m_value.number_unsigned <=
-                 std::numeric_limits<uint64_t>::(max)()) {
+                 (std::numeric_limits<uint64_t>::max)()) {
         // uint 64
         v.push_back(0xcf);
         add_to_vector(v, 8, j.m_value.number_unsigned);
@@ -6502,17 +6502,17 @@ private:
         if (j.m_value.number_integer <= 0x17) {
           add_to_vector(v, 1, j.m_value.number_integer);
         } else if (j.m_value.number_integer <=
-                   std::numeric_limits<uint8_t>::(max)()) {
+                   (std::numeric_limits<uint8_t>::max)()) {
           v.push_back(0x18);
           // one-byte uint8_t
           add_to_vector(v, 1, j.m_value.number_integer);
         } else if (j.m_value.number_integer <=
-                   std::numeric_limits<uint16_t>::(max)()) {
+                   (std::numeric_limits<uint16_t>::max)()) {
           v.push_back(0x19);
           // two-byte uint16_t
           add_to_vector(v, 2, j.m_value.number_integer);
         } else if (j.m_value.number_integer <=
-                   std::numeric_limits<uint32_t>::(max)()) {
+                   (std::numeric_limits<uint32_t>::max)()) {
           v.push_back(0x1a);
           // four-byte uint32_t
           add_to_vector(v, 4, j.m_value.number_integer);
@@ -6527,15 +6527,15 @@ private:
         const auto positive_number = -1 - j.m_value.number_integer;
         if (j.m_value.number_integer >= -24) {
           v.push_back(static_cast<uint8_t>(0x20 + positive_number));
-        } else if (positive_number <= std::numeric_limits<uint8_t>::(max)()) {
+        } else if (positive_number <= (std::numeric_limits<uint8_t>::max)()) {
           // int 8
           v.push_back(0x38);
           add_to_vector(v, 1, positive_number);
-        } else if (positive_number <= std::numeric_limits<uint16_t>::(max)()) {
+        } else if (positive_number <= (std::numeric_limits<uint16_t>::max)()) {
           // int 16
           v.push_back(0x39);
           add_to_vector(v, 2, positive_number);
-        } else if (positive_number <= std::numeric_limits<uint32_t>::(max)()) {
+        } else if (positive_number <= (std::numeric_limits<uint32_t>::max)()) {
           // int 32
           v.push_back(0x3a);
           add_to_vector(v, 4, positive_number);
@@ -6700,7 +6700,7 @@ private:
     }
 
     // second case: adding offset would result in overflow
-    if ((size > (std::numeric_limits<size_t>::(max)() - offset))) {
+    if ((size > ((std::numeric_limits<size_t>::max)() - offset))) {
       JSON_THROW(std::out_of_range("len+offset out of range"));
     }
 


### PR DESCRIPTION
My original PR https://github.com/pokowaka/jwt-cpp/commit/5a267d13179cbc1627c6b6188d4181b86b6e4518 did escape the macro expansion in a way that Visual Studio can handle, however apparently clang/gcc handles them differently.  This commit brings the json.hpp tweak in line with the cherry picked upstream change in nlohman/json (https://github.com/nlohmann/json/commit/95474e420de25ec7db4875e889201229820ef564) and should resolve the issue (https://github.com/pokowaka/jwt-cpp/issues/11)  However I do not have a development environment set up with clang or gcc on linux, so I have not been able to personally confirm this.