### PR TITLE
ssl_compat: fix memory leak in hmac

### DIFF
--- a/src/include/private/ssl_compat.h
+++ b/src/include/private/ssl_compat.h
@@ -21,7 +21,7 @@ class HMacCtx {
  public:
   HMacCtx() { HMAC_CTX_init(&ctx_); }
 
-  ~HMacCtx() {}
+  ~HMacCtx() { HMAC_CTX_cleanup(&ctx_); }
 
   HMAC_CTX* get() { return &ctx_; }
 


### PR DESCRIPTION
This should fix issue #18 

Signed-off-by: Jiri Novotny <jiri.novotny@logicelements.cz>