### PR TITLE
Fixed memory leak in evpmd

### DIFF
--- a/src/include/private/ssl_compat.h
+++ b/src/include/private/ssl_compat.h
@@ -9,7 +9,7 @@ class EvpMdCtx {
  public:
   EvpMdCtx() { EVP_MD_CTX_init(&ctx_); }
 
-  ~EvpMdCtx() {}
+  ~EvpMdCtx() { EVP_MD_CTX_cleanup(&ctx_); }
 
   EVP_MD_CTX* get() { return &ctx_; }
 


### PR DESCRIPTION
This memory leak is detected by gcc-sanitizers (enabled by configuring LD_FLAGS to -sanitize=address)