### PR TITLE
Don't catch polymorphic type InvalidClaimError by value

### DIFF
--- a/src/validators/claims/claimvalidator.cpp
+++ b/src/validators/claims/claimvalidator.cpp
@@ -57,7 +57,7 @@ bool AnyClaimValidator::IsValid(const json &claimset) const {
     try {
       if (validator->IsValid(claimset))
         return true;
-    } catch (InvalidClaimError ice) {
+    } catch (const InvalidClaimError &ice) {
     }
   }
   throw InvalidClaimError("None of the children validate");


### PR DESCRIPTION
This allows to build with newer gcc versions and -Werror.