### PR TITLE
Small fix for creating a conforming audience validator via ClaimValidatorFactory

### DIFF
--- a/src/validators/claims/claimvalidatorfactory.cpp
+++ b/src/validators/claims/claimvalidatorfactory.cpp
@@ -57,11 +57,11 @@ ClaimValidator *ClaimValidatorFactory::BuildInternal(const json &json) {
     ClaimValidator *constructed = nullptr;
     try {
         if (json.count("iss")) {
-            constructed = new ListClaimValidator("iss", BuildList(json["iss"]));
+            constructed = new IssValidator(BuildList(json["iss"]));
         } else if (json.count("sub")) {
-            constructed = new ListClaimValidator("sub", BuildList(json["sub"]));
+            constructed = new SubValidator(BuildList(json["sub"]));
         } else if (json.count("aud")) {
-            constructed = new ListClaimValidator("aud", BuildList(json["aud"]));
+            constructed = new AudValidator(BuildList(json["aud"]));
         } else if (json.count("exp")) {
             ::json val = json["exp"];
             ::json leeway = val["leeway"];

--- a/test/validators/claim_validators_factory_test.cpp
+++ b/test/validators/claim_validators_factory_test.cpp
@@ -37,6 +37,15 @@ TEST(parse_test, iss_not_a_stringlist) {
   ASSERT_THROW(ClaimValidatorFactory::Build(json), std::logic_error);
 }
 
+// This test tries to test that the factory has created an AudValidator
+// and not a basic ListClaimValidator
+TEST(parse_test, aud_array_value_in_payload) {
+    std::string json = "{ \"aud\" : [ \"foo\" ]}";
+    claim_ptr valid(ClaimValidatorFactory::Build(json));
+    ::json aud = {{"aud", ::json::array({"foo", "bar", "baz"})}};
+    EXPECT_TRUE(valid->IsValid(aud));
+}
+
 TEST(parse_test, optional_exp) {
   std::string json = "{ \"optional\" : { \"exp\" : { \"leeway\" : 32} } }";
   claim_ptr valid(ClaimValidatorFactory::Build(json));


### PR DESCRIPTION
... using the existing "AudValidator".  

Did similar change for "iss" and "sub" validators  even though these changes have no functional effect.